### PR TITLE
Fix log regex and add HTML export test

### DIFF
--- a/modular_analyzer/reporting_utils.py
+++ b/modular_analyzer/reporting_utils.py
@@ -103,12 +103,10 @@ def export_logs_to_html(log_file_path, output_html_path):
     import re
 
     pattern = re.compile(
-        pattern=re.compile(
-            r"(?P<datetime>\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d+\])\s+"  # [YYYY-MM-DD HH:MM:SS,ms]
-            r"\[\s*(?P<level>[A-Z]+)\]\s+"  # [LEVEL]
-            r"(?P<file>[^:]+):(?P<line>\d+)\s+-\s+"  # file.py:line -
-            r"(?P<message>.+)"  # message
-        )
+        r"(?P<datetime>\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d+\])\s+"
+        r"\[\s*(?P<level>[A-Z]+)\]\s+"
+        r"(?P<file>[^:]+):(?P<line>\d+)\s+-\s+"
+        r"(?P<message>.+)"
     )
     grouped = {}
     allowed_levels = {"ERROR", "WARNING"}

--- a/modular_analyzer/test_reporting_utils.py
+++ b/modular_analyzer/test_reporting_utils.py
@@ -1,0 +1,26 @@
+import sys
+import types
+
+# Stub pandas so reporting_utils can be imported without the real dependency.
+sys.modules.setdefault("pandas", types.ModuleType("pandas"))
+
+from modular_analyzer.reporting_utils import export_logs_to_html
+
+def test_export_logs_to_html(tmp_path):
+    log_file = tmp_path / "sample.log"
+    html_file = tmp_path / "report.html"
+    log_file.write_text(
+        "[2024-01-01 12:34:56,789] [ERROR] test.py:10 - Something went wrong\n"
+        "[2024-01-01 12:35:00,123] [WARNING] test.py:20 - Something suspicious\n"
+        "[2024-01-01 12:35:01,000] [INFO] test.py:30 - Info message\n"
+        "Unstructured line\n"
+    )
+
+    export_logs_to_html(str(log_file), str(html_file))
+
+    html = html_file.read_text()
+    assert "Error Log Report" in html
+    assert "Something went wrong" in html
+    assert "Something suspicious" in html
+    assert "Unstructured line" in html
+    assert "Info message" not in html


### PR DESCRIPTION
## Summary
- fix `export_logs_to_html` regex compilation
- add `test_reporting_utils` with sample log file

## Testing
- `python -m pytest modular_analyzer/test_reporting_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685f26daac448331b693a69075eea58e