### PR TITLE
Move invalid input test to tests directory

### DIFF
--- a/modular_analyzer/pdf_utils.py
+++ b/modular_analyzer/pdf_utils.py
@@ -31,19 +31,3 @@ def process_pages_concurrently(args_list, processor):
     return [r for r in results if r is not None]
 
 
-# === TEST HARNESS FOR KNOWN-INVALID INPUT ===
-def test_read_text_with_invalid_image():
-    import numpy as np
-    from modular_analyzer.ocr_utils import read_text, initialize_reader
-
-    reader = initialize_reader("paddleocr")
-    try:
-        result = read_text(reader, None)  # force failure
-    except ValueError as e:
-        print("✅ Caught expected ValueError:", e)
-
-    try:
-        bad_array = np.array([[]])
-        result = read_text(reader, bad_array)
-    except ValueError as e:
-        print("✅ Caught expected ValueError on bad shape:", e)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/test_read_text_invalid_image.py
+++ b/tests/test_read_text_invalid_image.py
@@ -1,0 +1,23 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+try:
+    import numpy as np
+except Exception:  # numpy might not be installed in minimal test env
+    np = None
+
+ocr_utils = pytest.importorskip('modular_analyzer.ocr_utils')
+read_text = ocr_utils.read_text
+
+@pytest.mark.skipif(np is None, reason="numpy is required for this test")
+def test_read_text_with_none():
+    with pytest.raises(ValueError):
+        read_text(None)
+
+@pytest.mark.skipif(np is None, reason="numpy is required for this test")
+def test_read_text_with_empty_array():
+    with pytest.raises(ValueError):
+        read_text(np.array([[]]))


### PR DESCRIPTION
## Summary
- remove `test_read_text_with_invalid_image` from `pdf_utils`
- add pytest configuration
- create pytest for invalid inputs to `read_text`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f26eb676c8331bf9027c9f34a29fb