### PR TITLE
Fix issue_log usage and add regression test

### DIFF
--- a/modular_analyzer/page_processor.py
+++ b/modular_analyzer/page_processor.py
@@ -50,6 +50,7 @@ def process_page(task: PageTask):
     entry = {"Page": page_num}
     ticket_issue = ""
     thumbnail_log = []
+    issue_log = []
 
     def log_issue(issue_type: str, field: str):
         issue_log.append({
@@ -237,4 +238,5 @@ def process_page(task: PageTask):
         "ticket_issue": ticket_issue,
         "thumbnails": thumbnail_log,
         "timing": {"Page": page_num, "DurationSeconds": duration},
+        "issue_log": issue_log,
     }

--- a/tests/test_process_page.py
+++ b/tests/test_process_page.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import types
+
+# Stub heavy optional dependencies before importing page_processor
+for name in [
+    "pandas", "cv2", "onnxruntime", "openpyxl", "openpyxl.styles",
+    "PIL", "doctr", "doctr.io", "doctr.models", "yaml"
+]:
+    if name not in sys.modules:
+        sys.modules[name] = types.ModuleType(name)
+
+# Provide minimal attributes required by file_utils and ocr_utils
+sys.modules["openpyxl"].load_workbook = lambda *a, **k: None
+sys.modules["openpyxl.styles"].PatternFill = lambda *a, **k: None
+
+fake_pil = sys.modules.get("PIL")
+pil_image_mod = types.ModuleType("PIL.Image")
+class DummyImage:
+    pass
+pil_image_mod.Image = DummyImage
+sys.modules["PIL.Image"] = pil_image_mod
+fake_pil.Image = pil_image_mod
+image_draw_mod = types.ModuleType("PIL.ImageDraw")
+sys.modules["PIL.ImageDraw"] = image_draw_mod
+fake_pil.ImageDraw = image_draw_mod
+
+doctr_io = sys.modules.get("doctr.io")
+doctr_io.DocumentFile = type("DocumentFile", (), {})
+doctr_models = sys.modules.get("doctr.models")
+doctr_models.ocr_predictor = lambda *a, **k: object()
+yaml_mod = sys.modules.get("yaml")
+yaml_mod.safe_load = lambda *a, **k: {}
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from modular_analyzer.types import PageTask
+def test_process_page_runs(monkeypatch, tmp_path):
+    monkeypatch.setitem(sys.modules, "numpy", types.ModuleType("numpy"))
+    import modular_analyzer.page_processor as pp
+    monkeypatch.setattr(pp, "initialize_reader", lambda backend="doctr": object())
+
+    task = PageTask(page_idx=0, img=object(), fields={}, output_dir=str(tmp_path), vendor="v", date="d")
+    result = pp.process_page(task)
+    assert result["issue_log"] == []


### PR DESCRIPTION
## Summary
- prevent `NameError` in `process_page` by defining `issue_log`
- return logged issues so callers can access them
- add regression test covering `process_page`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687121d446e08331aa4165beb778cf4c