### PR TITLE
Fix color_code_excel path handling

### DIFF
--- a/modular_analyzer/file_utils.py
+++ b/modular_analyzer/file_utils.py
@@ -31,11 +31,11 @@ def save_csv(data, columns, filepath):
         writer.writerows(data)
 
 
-def color_code_excel(output_dir):
+def color_code_excel(csv_path):
+    """Convert a CSV of ticket numbers to an Excel file with highlights."""
     try:
-        filepath = os.path.join(output_dir, "ticket_numbers.csv")
-        df = pd.read_csv(filepath)
-        xlsx_path = filepath.replace(".csv", ".xlsx")
+        df = pd.read_csv(csv_path)
+        xlsx_path = csv_path.replace(".csv", ".xlsx")
         df.to_excel(xlsx_path, index=False)
 
         wb = load_workbook(xlsx_path)

--- a/modular_analyzer/main.py
+++ b/modular_analyzer/main.py
@@ -127,6 +127,7 @@ def main():
     timings = [r["timing"] for r in results]
 
     save_entries_to_excel(entries, output_dir, structured_name)
+    csv_path = os.path.join(output_dir, f"{structured_name}_ticket_numbers.csv")
     save_csv(ticket_issues, columns=["Page", "Issue"],
              filepath=os.path.join(output_dir, "ticket_issues.csv"))
     save_csv(thumbnails, columns=["Page", "Field", "ThumbnailPath"],
@@ -135,7 +136,7 @@ def main():
              filepath=os.path.join(output_dir, "process_analysis.csv"))
 
     collect_summary_report(output_dir, entries)
-    color_code_excel(output_dir)
+    color_code_excel(csv_path)
     zip_folder(os.path.join(output_dir, "valid"), os.path.join(output_dir, "valid_pages.zip"))
 
     logging.info("Processing complete. Output saved.")

--- a/tests/test_color_code_excel.py
+++ b/tests/test_color_code_excel.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import pytest
+
+pytest.importorskip('pandas')
+openpyxl = pytest.importorskip('openpyxl')
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from modular_analyzer.file_utils import save_entries_to_excel, color_code_excel
+
+
+def test_color_code_excel_round_trip(tmp_path):
+    entries = [
+        {"Page": 1, "Ticket": "missing data"},
+        {"Page": 2, "Ticket": "valid"},
+    ]
+
+    save_entries_to_excel(entries, tmp_path, "sample")
+    csv_path = tmp_path / "sample_ticket_numbers.csv"
+
+    assert csv_path.exists()
+
+    color_code_excel(str(csv_path))
+
+    xlsx_path = tmp_path / "sample_ticket_numbers.xlsx"
+    assert xlsx_path.exists()


### PR DESCRIPTION
## Summary
- allow `color_code_excel` to accept a CSV path directly
- update `main.py` to pass the generated CSV
- add unit test covering CSV round‑trip

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687121d66f6c8331a299531ce5774686