### PR TITLE
Pin scikit-learn 1.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ handwriting. Results are saved to CSV/Excel for further review.
 - PyMuPDF & pdf2image
 - Tesseract via `pytesseract`
 - ONNX Runtime
-- pandas, numpy, scikit-learn
+- pandas, numpy, scikit-learn==1.6.1
 
 See [`environment.yml`](environment.yml) for the list of required packages
 and environment setup instructions.

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
       - pytesseract==0.3.13
       - numpy==2.0.2
       - pandas==2.3.0
+      - scikit-learn==1.6.1
       - pillow==11.2.1
       - scikit-image==0.24.0
       - torch==2.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ onnxruntime==1.19.2
 numpy==1.24.4
 pillow==11.2.1
 pandas==1.5.3
-scikit-learn==1.7.0
+scikit-learn==1.6.1
 scikit-image==0.25.2
 matplotlib==3.10.1
 tqdm==4.67.1


### PR DESCRIPTION
## Summary
- update scikit-learn pin to 1.6.1
- list scikit-learn 1.6.1 in the environment file
- document the version in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871926490a88331a27e8b3b1a2169b1