### PR TITLE
Fix extract_text_fields signature

### DIFF
--- a/modular_analyzer/ocr_utils.py
+++ b/modular_analyzer/ocr_utils.py
@@ -205,4 +205,4 @@ def extract_text_fields(img: Image.Image, reader, backend: str = "doctr") -> lis
     Returns a list of tuples with (bbox, text, confidence).
     """
     region_array = np.array(img.convert("RGB"))
-    return read_text(reader, region_array, backend=backend)
+    return read_text(region_array, backend=backend)

--- a/tests/test_extract_text_fields.py
+++ b/tests/test_extract_text_fields.py
@@ -1,0 +1,23 @@
+import pytest
+
+ocr_utils = pytest.importorskip('modular_analyzer.ocr_utils')
+np = pytest.importorskip('numpy')
+
+class DummyImage:
+    def convert(self, mode):
+        assert mode == "RGB"
+        return np.zeros((1, 1, 3), dtype=np.uint8)
+
+def test_extract_text_fields_uses_read_text(monkeypatch):
+    called = {}
+    def fake_read_text(image, backend="doctr"):
+        called['image_type'] = type(image)
+        called['backend'] = backend
+        return [("box", "text", 1.0)]
+
+    monkeypatch.setattr(ocr_utils, 'read_text', fake_read_text)
+    img = DummyImage()
+    result = ocr_utils.extract_text_fields(img, reader=object(), backend="onnxruntime")
+    assert result == [("box", "text", 1.0)]
+    assert called['backend'] == "onnxruntime"
+    assert issubclass(called['image_type'], np.ndarray)


### PR DESCRIPTION
## Summary
- fix misuse of `read_text` inside `extract_text_fields`
- test that `extract_text_fields` calls `read_text` properly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687192680a1883318e339eaaf7cfd72b