### PR TITLE
Ensure fitz documents closed after reading PDFs

### DIFF
--- a/modular_analyzer/pdf_utils.py
+++ b/modular_analyzer/pdf_utils.py
@@ -10,12 +10,12 @@ def convert_pdf_to_images(pdf_path):
     :param pdf_path: Path to the PDF file.
     :return: List of PIL Image objects, one per page.
     """
-    doc = fitz.open(pdf_path)
     images = []
-    for page in doc:
-        pix = page.get_pixmap()
-        img = Image.frombytes("RGB", (pix.width, pix.height), pix.samples)
-        images.append(img)
+    with fitz.open(pdf_path) as doc:
+        for page in doc:
+            pix = page.get_pixmap()
+            img = Image.frombytes("RGB", (pix.width, pix.height), pix.samples)
+            images.append(img)
     return images
 
 

--- a/tests/test_pdf_utils_handles.py
+++ b/tests/test_pdf_utils_handles.py
@@ -1,0 +1,28 @@
+import os
+import pytest
+
+fitz = pytest.importorskip("fitz")
+
+from modular_analyzer.pdf_utils import convert_pdf_to_images
+
+
+def _open_targets():
+    targets = []
+    for fd in os.listdir("/proc/self/fd"):
+        try:
+            targets.append(os.readlink(f"/proc/self/fd/{fd}"))
+        except OSError:
+            continue
+    return targets
+
+
+def test_convert_pdf_to_images_closes_file(tmp_path):
+    pdf_path = tmp_path / "sample.pdf"
+    doc = fitz.open()
+    doc.new_page()
+    doc.save(str(pdf_path))
+    doc.close()
+
+    convert_pdf_to_images(str(pdf_path))
+
+    assert str(pdf_path) not in _open_targets()


### PR DESCRIPTION
## Summary
- open PDFs via context manager in `convert_pdf_to_images`
- add regression test to check no file handles remain after reading a PDF

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68719269aff08331ae99c2abc92e2ec1