### PR TITLE
Fix auto_export_logs check and add test

### DIFF
--- a/modular_analyzer/reporting_utils.py
+++ b/modular_analyzer/reporting_utils.py
@@ -146,8 +146,9 @@ def export_logs_to_html(log_file_path, output_html_path):
 def auto_export_logs():
     try:
         log_file = "error.log"
-        export_logs_to_csv(log_file, "log_report.csv")
-        export_logs_to_html(log_file, "log_report.html")
+        if os.path.exists(log_file):
+            export_logs_to_csv(log_file, "log_report.csv")
+            export_logs_to_html(log_file, "log_report.html")
     except Exception as e:
         print(f"[auto_export_logs] Export failed: {e}")
 

--- a/tests/test_reporting_utils.py
+++ b/tests/test_reporting_utils.py
@@ -4,7 +4,7 @@ import types
 # Stub pandas so reporting_utils can be imported without the real dependency.
 sys.modules.setdefault("pandas", types.ModuleType("pandas"))
 
-from modular_analyzer.reporting_utils import export_logs_to_html
+from modular_analyzer.reporting_utils import export_logs_to_html, auto_export_logs
 
 def test_export_logs_to_html(tmp_path):
     log_file = tmp_path / "sample.log"
@@ -24,3 +24,11 @@ def test_export_logs_to_html(tmp_path):
     assert "Something suspicious" in html
     assert "Unstructured line" in html
     assert "Info message" not in html
+
+
+def test_auto_export_logs_no_file(tmp_path, monkeypatch):
+    """auto_export_logs should not raise if error.log is missing."""
+    monkeypatch.chdir(tmp_path)
+    # Ensure no error.log exists
+    assert not (tmp_path / "error.log").exists()
+    auto_export_logs()  # should run without exceptions


### PR DESCRIPTION
## Summary
- avoid export crash when no error log exists
- test auto_export_logs without error log

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871926c117883319c7d32976c25b348