### PR TITLE
Add orientation correction option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The analyzer provides:
 - ONNX-based handwriting recognition
 - Optional template matching for ticket numbers
 - Concurrent processing of pages using Python's multiprocessing
+- Automatic page orientation correction (Tesseract or Doctr)
 
 ## Usage
 1. Create and activate the Conda environment:

--- a/docs/DETAILED_README.md
+++ b/docs/DETAILED_README.md
@@ -13,6 +13,7 @@ OCR/ICR engines to read printed text and handwriting, and includes template matc
 * **Handwriting Detection**: Heuristic and deep-learning based methods to detect handwritten regions.
 * **Template Matching**: Locates known form elements using OpenCV template matching.
 * **Concurrent Processing**: Leverages Python’s `multiprocessing` for fast, parallel page processing.
+* **Orientation Correction**: Automatically rotates pages using Tesseract or Doctr.
 * **Vendor Configuration**: Built-in support for multiple ticket vendors with custom XML mappings.
 
 ---
@@ -74,6 +75,7 @@ Ticket_Analyzer/
 * Vendor XML mappings live in `modular_analyzer/xml/`. Add or update files for new vendors.
 
 * Adjust `launch_analyzer.py` arguments or modify `main.py` defaults as needed (e.g., output directory, logging).
+* Set `orientation_check` in `configs/ocr_config.yaml` to `tesseract`, `doctr`, or `none`.
 
 ---
 

--- a/modular_analyzer/configs/ocr_config.yaml
+++ b/modular_analyzer/configs/ocr_config.yaml
@@ -1,2 +1,3 @@
 ocr_backend: doctr
 use_onnx_fallback: true
+orientation_check: tesseract  # tesseract, doctr, or none

--- a/modular_analyzer/page_processor.py
+++ b/modular_analyzer/page_processor.py
@@ -13,7 +13,8 @@ from modular_analyzer.ocr_utils import (
     detect_handwriting,
     is_handwriting_deep,
     template_match,
-    ensure_region_array
+    ensure_region_array,
+    correct_image_orientation
 )
 from modular_analyzer.types import PageTask
 
@@ -21,6 +22,7 @@ from modular_analyzer.types import PageTask
 CONFIG_PATH = os.path.join(os.path.dirname(__file__), "configs", "ocr_config.yaml")
 OCR_CONFIG = load_yaml(CONFIG_PATH) if os.path.exists(CONFIG_PATH) else {}
 USE_ONNX_FALLBACK = OCR_CONFIG.get("use_onnx_fallback", True)
+ORIENTATION_METHOD = OCR_CONFIG.get("orientation_check", "tesseract")
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +42,7 @@ def process_page(task: PageTask):
     reader_hand = initialize_reader("onnxruntime") if USE_ONNX_FALLBACK else None
 
     page_num = page_idx + 1
+    img = correct_image_orientation(img, page_num=page_num, method=ORIENTATION_METHOD)
     crops_dir = os.path.join(output_dir, "crops")
     thumbnails_dir = os.path.join(output_dir, "thumbnails")
     logs_dir = os.path.join(output_dir, "logs")

--- a/tests/test_correct_image_orientation.py
+++ b/tests/test_correct_image_orientation.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import types
+import pytest
+
+# Stub heavy optional dependencies before importing ocr_utils
+for name in [
+    "cv2", "onnxruntime", "doctr", "doctr.io", "doctr.models", "pytesseract", "PIL", "PIL.Image", "PIL.ImageDraw"
+]:
+    if name not in sys.modules:
+        sys.modules[name] = types.ModuleType(name)
+
+fake_pil = sys.modules.get("PIL")
+pil_image_mod = types.ModuleType("PIL.Image")
+class DummyImage:
+    pass
+pil_image_mod.Image = DummyImage
+sys.modules["PIL.Image"] = pil_image_mod
+fake_pil.Image = pil_image_mod
+doctr_io = sys.modules.get("doctr.io")
+doctr_io.DocumentFile = type("DocumentFile", (), {})
+doctr_models = sys.modules.get("doctr.models")
+doctr_models.ocr_predictor = lambda *a, **k: object()
+
+np = pytest.importorskip("numpy")
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+ocr_utils = __import__('modular_analyzer.ocr_utils', fromlist=['correct_image_orientation'])
+correct_image_orientation = ocr_utils.correct_image_orientation
+
+Image = pytest.importorskip('PIL').Image
+
+
+def test_orientation_none():
+    if Image is None:
+        return
+    img = Image.new('RGB', (10, 10))
+    result = correct_image_orientation(img, method='none')
+    assert result is img
+


### PR DESCRIPTION
## Summary
- support correcting page orientation using tesseract or doctr
- expose `orientation_check` in `ocr_config.yaml`
- document orientation feature in README and detailed docs
- test `correct_image_orientation`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871937b24e88331aaf0e1a93352a666