### PR TITLE
Fix Python 3.9 compatibility

### DIFF
--- a/docs/DETAILED_README.md
+++ b/docs/DETAILED_README.md
@@ -43,7 +43,7 @@ Ticket_Analyzer/
 1. **Set up a Conda environment** (recommended on Windows):
 
    ```bash
-   conda create -n ocr_env python=3.10 pip
+   conda create -n ocr_env python=3.9 pip
    conda activate ocr_env
    ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ numpy==1.24.4
 pillow==11.2.1
 pandas==1.5.3
 scikit-learn==1.6.1
-scikit-image==0.25.2
+scikit-image==0.24.0
 matplotlib==3.10.1
 tqdm==4.67.1
 


### PR DESCRIPTION
## Summary
- align scikit-image dependency with Python 3.9
- update docs to use Python 3.9 in conda setup instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871978a74588331a60c75bc63dbc836