### PR TITLE
Fix shapely dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ aiosignal==1.3.2
 async-timeout==4.0.3
 coloredlogs==15.0.1
 prettytable==3.16.0
-shapely==2.1.1
+shapely==2.0.3
 fsspec==2025.5.1
 ujson==5.10.0
 regex==2024.11.6


### PR DESCRIPTION
## Summary
- ensure shapely uses a released version

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871990086048331b2921ab04429d25f