### PR TITLE
Add receipt processing project

### DIFF
--- a/receipt_processing/main.py
+++ b/receipt_processing/main.py
@@ -1,0 +1,98 @@
+"""Receipt Processing App using DocTR (OCR)."""
+
+from __future__ import annotations
+
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+from .utils import CATEGORY_MAP, ReceiptFields, extract_fields
+
+
+# --- Configuration ---
+INPUT_DIR = Path("C:/Receipts/input")
+OUTPUT_DIR = Path("C:/Receipts/processed")
+LOG_FILE = Path("C:/Receipts/receipt_log.xlsx")
+
+
+# --- Lazy OCR initialization ---
+def _get_ocr_model():
+    from doctr.models import ocr_predictor
+    return ocr_predictor(
+        det_arch="db_resnet18",
+        reco_arch="crnn_mobilenet_v3_small",
+        pretrained=True,
+    )
+
+
+# --- Utility: OCR processing ---
+def extract_text(filepath: Path) -> Iterable[str]:
+    """Run OCR on an image or PDF and return a list of text lines."""
+    from doctr.io import DocumentFile
+
+    if filepath.suffix.lower() == ".pdf":
+        doc = DocumentFile.from_pdf(str(filepath))
+    else:
+        doc = DocumentFile.from_images([str(filepath)])
+
+    model = _get_ocr_model()
+    result = model(doc)
+    export = result.export()
+    lines: list[str] = []
+    for page in export["pages"]:
+        for block in page.get("blocks", []):
+            for line in block.get("lines", []):
+                text = "".join(word["value"] for word in line.get("words", []))
+                lines.append(text)
+    return lines
+
+
+# --- Main receipt processor ---
+def process_receipt(filepath: Path) -> ReceiptFields:
+    print(f"Processing {filepath.name}...")
+    lines = extract_text(filepath)
+    fields = extract_fields(lines, CATEGORY_MAP)
+
+    # Move file to output folder
+    category_folder = OUTPUT_DIR / fields.category
+    category_folder.mkdir(parents=True, exist_ok=True)
+    new_path = category_folder / filepath.name
+    shutil.move(str(filepath), str(new_path))
+
+    return fields
+
+
+def run_batch() -> None:
+    INPUT_DIR.mkdir(parents=True, exist_ok=True)
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    records: list[dict[str, str]] = []
+    for file in INPUT_DIR.glob("*"):
+        if file.suffix.lower() in {".jpg", ".jpeg", ".png", ".pdf"}:
+            try:
+                fields = process_receipt(file)
+                record = {
+                    "filename": file.name,
+                    "vendor": fields.vendor,
+                    "date": fields.date,
+                    "total": fields.total,
+                    "category": fields.category,
+                    "processed_time": datetime.now().isoformat(),
+                }
+                records.append(record)
+            except Exception as e:  # pragma: no cover - runtime protection
+                print(f"Error: {file.name} - {e}")
+
+    if records:
+        df = pd.DataFrame(records)
+        if LOG_FILE.exists():
+            existing = pd.read_excel(LOG_FILE)
+            df = pd.concat([existing, df], ignore_index=True)
+        df.to_excel(LOG_FILE, index=False)
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry
+    run_batch()

--- a/receipt_processing/utils.py
+++ b/receipt_processing/utils.py
@@ -1,0 +1,47 @@
+"""Utility functions for the receipt processing app."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable
+
+# Default categories mapped to vendor keywords
+CATEGORY_MAP: dict[str, list[str]] = {
+    "fuel": ["shell", "chevron", "exxon", "gas"],
+    "meals": ["restaurant", "grill", "mcdonald", "subway", "burger"],
+    "supplies": ["office depot", "staples", "lowes", "home depot"],
+}
+
+@dataclass
+class ReceiptFields:
+    vendor: str
+    date: str
+    total: str
+    category: str
+    lines: list[str]
+
+
+def extract_fields(lines: Iterable[str], category_map: dict[str, list[str]] | None = None) -> ReceiptFields:
+    """Extract key information from the OCR text lines."""
+    if category_map is None:
+        category_map = CATEGORY_MAP
+
+    lines = [line.strip() for line in lines]
+    full_text = "\n".join(lines).lower()
+
+    date_match = re.search(r"\b(\d{1,2}[/-]\d{1,2}[/-]\d{2,4})\b", full_text)
+    total_match = re.search(r"(?:total|amount due)[^\d]*(\d+[.,]?\d*)", full_text)
+
+    date = date_match.group(1) if date_match else ""
+    total = total_match.group(1) if total_match else ""
+
+    vendor = lines[0] if lines else "Unknown"
+
+    category = "uncategorized"
+    for cat, keywords in category_map.items():
+        if any(kw in full_text for kw in keywords):
+            category = cat
+            break
+
+    return ReceiptFields(vendor=vendor, date=date, total=total, category=category, lines=list(lines))

--- a/tests/test_receipt_utils.py
+++ b/tests/test_receipt_utils.py
@@ -1,0 +1,26 @@
+from receipt_processing.utils import extract_fields, ReceiptFields, CATEGORY_MAP
+
+
+def test_extract_fields_basic():
+    lines = [
+        "Shell Gas Station",
+        "Date: 01/02/2024",
+        "Total: $45.67",
+    ]
+    fields = extract_fields(lines)
+    assert isinstance(fields, ReceiptFields)
+    assert fields.vendor == "Shell Gas Station"
+    assert fields.date == "01/02/2024"
+    assert fields.total == "45.67"
+    assert fields.category == "fuel"
+
+
+def test_extract_fields_uncategorized():
+    lines = [
+        "Unknown Vendor",
+        "Amount Due 12.00",
+    ]
+    fields = extract_fields(lines)
+    assert fields.category == "uncategorized"
+    assert fields.total == "12.00"
+


### PR DESCRIPTION
## Summary
- add simple receipt processing project using DocTR OCR
- implement utility functions to categorize receipts
- include sample batch processor script
- test new extraction utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688956fb232483319b4a6cb8982a5064